### PR TITLE
Reintroduced :locked so the version.locked? check works

### DIFF
--- a/lib/fastly/version.rb
+++ b/lib/fastly/version.rb
@@ -1,7 +1,7 @@
 class Fastly
   # An iteration of your configuration
   class Version < Base
-    attr_accessor :service_id, :number, :name, :active, :staging, :testing, :deployed, :comment
+    attr_accessor :service_id, :number, :name, :active, :staging, :testing, :deployed, :comment, :locked
 
     ##
     # :attr: service_id


### PR DESCRIPTION
Reintroduced `:locked` to `version.rb` to make the locked of `true == @locked` pass. 

Tested against Ruby 2.2.3p173 based on gem 1.4.2.